### PR TITLE
Custom populate to retrieve model

### DIFF
--- a/config/controller/admin/block/crud.config.php
+++ b/config/controller/admin/block/crud.config.php
@@ -161,6 +161,9 @@ return array(
         ),
         'block_template' => array(
             'label' => '',
+            'validation' => array(
+                'required',
+            ),
         ),
         'block_link' => array(
             'label' => __('Link'),

--- a/views/admin/block/retrieve_model.view.php
+++ b/views/admin/block/retrieve_model.view.php
@@ -26,17 +26,23 @@
         $field = array_merge(array(
             'type' => 'text',
         ), $field);
-        $t_id = uniqid($field['field']);
+        $t_id = uniqid(\Arr::get($field, 'field', $key));
         $value = '';
-        switch ($field['type']) {
-            case 'wysiwyg' :
-                $value = $item->wysiwygs->{$field['field']};
-                break;
-            case 'text' :
+        $populateCallback = \Arr::get($field, 'populate');
+        if ($populateCallback && is_callable($populateCallback)) {
+            $value = call_user_func($populateCallback, $item);
+        } else {
+            switch ($field['type']) {
+                case 'wysiwyg' :
+                    $value = $item->wysiwygs->{$field['field']};
+                    break;
+                case 'text' :
                 default :
                     $value = $item->{$field['field']};
-                break;
+                    break;
+            }
         }
+
         ?>
         <p>
             <input type="checkbox" name="<?= $key ?>" id="<?= $t_id ?>" value="1" />


### PR DESCRIPTION
That feature allow user to set a populate callback function into the data_mapping for his connection model configuration.
This callback takes the item in parameter.

In an other point : block template is now required in the CRUD config to avoid any SQL error.
