### PR TITLE
Reuse parent "action_form" in crud controller

### DIFF
--- a/classes/controller/admin/block/crud.ctrl.php
+++ b/classes/controller/admin/block/crud.ctrl.php
@@ -91,26 +91,7 @@ class Controller_Admin_Block_Crud extends \Nos\Controller_Admin_Crud
     {
         $context = Input::get('context', $this->item->block_context);
         $this->config['fields']['columns']['form']['options'] = \Arr::assoc_to_keyval(\Novius\Blocks\Model_Column::find('all', array('where' => array('blco_context' => $context))), 'blco_id', 'blco_title');
-        $this->item = $this->crud_item($id);
-        $this->clone = clone $this->item;
-        $this->is_new = $this->item->is_new();
-        if ($this->is_new) {
-            $this->init_item();
-        }
-        $this->checkPermission($this->is_new ? 'add' : 'edit');
-
-        $fields = $this->fields($this->config['fields']);
-        $fieldset = \Fieldset::build_from_config($fields, $this->item, $this->build_from_config());
-        $fieldset = $this->fieldset($fieldset);
-
-        $view_params = $this->view_params();
-        $view_params['fieldset'] = $fieldset;
-
-        // We can't do this form inside the view_params() method, because additional vars (added
-        // after the reference was created) won't be available from the reference
-        $view_params['view_params'] = &$view_params;
-
-        return \View::forge($this->config['views'][$this->is_new ? 'insert' : 'update'], $view_params, false);
+        return parent::action_form($id);
     }
 
     /**


### PR DESCRIPTION
It seems that it is the exact same code except for the lines adding css which are missing and may be needed.
