### PR TITLE
improve the way crud action is called in ajax

### DIFF
--- a/classes/controller/admin/block/crud.ctrl.php
+++ b/classes/controller/admin/block/crud.ctrl.php
@@ -191,16 +191,21 @@ class Controller_Admin_Block_Crud extends \Nos\Controller_Admin_Crud
      * @param $model_id
      * @return bool|\Fuel\Core\View
      */
-    public function action_get_model_assoc_infos ($config_key, $model_id)
+    public function action_get_model_assoc_infos ()
     {
+        $config_key = \Input::get('key', false);
+        $model_id = \Input::get('id', false);
+        if (empty($config_key) || empty($model_id)) {
+            exit();
+        }
         $models = \Config::load('novius_blocks::connection_model', true);
         if (!isset($models[$config_key])) {
-            return false;
+            exit();
         }
         $model_config = $models[$config_key];
         $class_name = $model_config['model'];
         if (!$item = $class_name::find($model_id)) {
-            return false;
+            exit();
         }
 
         $return = \View::forge('novius_blocks::admin/block/model_assoc_infos', array(

--- a/static/js/admin/blocks.js
+++ b/static/js/admin/blocks.js
@@ -94,7 +94,11 @@ define(
                     $wrapper_autocompletion.hide();
                     // We search for the associated content
                     $nos.ajax({
-                        'url': 'admin/novius_blocks/block/crud/get_model_assoc_infos/' + model_key + '/' + model_id,
+                        'url': 'admin/novius_blocks/block/crud/get_model_assoc_infos',
+                        data : {
+                            key : model_key,
+                            id : model_id
+                        },
                         'success' : function(vue) {
                             $wrapper_assoc_model_done.html(vue);
                             $wrapper_assoc_model_done.fadeIn();


### PR DESCRIPTION
it prevents from having a 404 when the namespace is given with the model name as key
which leads to call an url like admin/novius_blocks/block/crud/get_model_assoc_infos/Namespace/Model/id
