### PR TITLE
no show title input if template block no chosen

### DIFF
--- a/classes/controller/admin/block/crud.ctrl.php
+++ b/classes/controller/admin/block/crud.ctrl.php
@@ -101,6 +101,10 @@ class Controller_Admin_Block_Crud extends \Nos\Controller_Admin_Crud
             }
             $layoutExpanderKey = "layout.0.params.content.template.params.title";
             \Arr::set($this->config, $layoutExpanderKey, \Arr::get($this->config, $layoutExpanderKey, '')." : ".$blockConfig['title']);
+        } else {
+            //select template first
+            //if template no chosen, don't show the title input
+            \Arr::set($this->config, "layout.0.params.title", array());
         }
 
         $this->config['layout_insert'] = $this->config['layout'];

--- a/classes/controller/admin/block/crud.ctrl.php
+++ b/classes/controller/admin/block/crud.ctrl.php
@@ -104,7 +104,7 @@ class Controller_Admin_Block_Crud extends \Nos\Controller_Admin_Crud
         } else {
             //select template first
             //if template no chosen, don't show the title input
-            \Arr::set($this->config, "layout.0.params.title", array());
+            \Arr::set($this->config, "layout.0.params.title", false);
         }
 
         $this->config['layout_insert'] = $this->config['layout'];


### PR DESCRIPTION
When we want to add block, the title input is display.
But if we choose a template, the value of the title input don't display.

 So, if it's new block, we choose first the template, and after we can change the input of this template.
**Before choose a template block :**
![new item](https://user-images.githubusercontent.com/17598922/30275251-07fd60aa-9701-11e7-96ce-2d4e6026e4b1.png)

**After choose a template**
![new item template chosen](https://user-images.githubusercontent.com/17598922/30275250-07e60874-9701-11e7-9968-587bb89ddcc1.png)

